### PR TITLE
add confidence % to result list

### DIFF
--- a/app/controllers/MainController.js
+++ b/app/controllers/MainController.js
@@ -158,7 +158,8 @@ function summaryFor( data ){
   if( data && Array.isArray( data.features ) ){
     var maxWidth = String(data.features.length).length;
     data.features.forEach( function( feat, i ){
-      summary += leftPad( i+1, maxWidth, ' ' ) + ')\t' + feat.properties.label + '\n';
+      var perc = Math.floor( feat.properties.confidence * 100 );
+      summary += leftPad( i+1, maxWidth, ' ' ) + '.\t' + perc + '%. ' + feat.properties.label + '\n';
     });
   }
 


### PR DESCRIPTION
experiment: we probably don't want to merge this

some old code I had lying around on my laptop, it adds confidence % to each row in the results.

I'm not that interested in merging it, just putting it here in case anyone else wants it.

```
 1.	95%. London, England, United Kingdom
 2.	87%. Greater London, England, United Kingdom
 3.	73%. London, ON, Canada
 4.	67%. City of London, England, United Kingdom
 5.	66%. East London, South Africa
 6.	66%. East London, South Africa
 7.	66%. East New London, New London, CT, USA
 8.	71%. London, OH, USA
 9.	71%. London, OH, USA
10.	71%. London, KY, USA
```