### PR TITLE
Add geocode.earth production and dev endpoints

### DIFF
--- a/app/controllers/MainController.js
+++ b/app/controllers/MainController.js
@@ -11,7 +11,9 @@ function MainController( $scope, $location, $http, $rootScope ){
     'http://pelias.mapzen.com': 'mapzen-hDy3Ygk',
     'http://pelias.dev.mapzen.com': 'mapzen-iPi9LiS',
     'http://pelias.prodbuild.mapzen.com': '',
-    'http://pelias2.dev.mapzen.com': ''
+    'http://pelias2.dev.mapzen.com': '',
+    'https://api.geocode.earth': 'ge-6361345754ea1287',
+    'https://api.dev.geocode.earth': 'ge-6361345754ea1287'
   };
 
   $scope.endpoints = [];
@@ -105,7 +107,7 @@ function MainController( $scope, $location, $http, $rootScope ){
     $scope.submit();
   };
   window.resetEndpoints = function(){
-    window.saveEndpoints(['https://search.mapzen.com','http://pelias.prodbuild.mapzen.com','http://pelias.dev.mapzen.com']);
+    window.saveEndpoints(['https://search.mapzen.com/', 'https://api.geocode.earth', 'https://api.dev.geocode.earth']);
     window.loadEndpoints();
   };
   window.saveEndpoints = function( endpoints ){

--- a/app/controllers/MainController.js
+++ b/app/controllers/MainController.js
@@ -125,7 +125,7 @@ function MainController( $scope, $location, $http, $rootScope ){
   };
   console.info( 'funfact: you can use getEndpoints() and setEndpoints() to change which hosts are being queried, or use resetEndpoints() to reset to defaults');
 
-  var currentVersion = 4;
+  var currentVersion = 5;
   var version = window.localStorage.getItem('version');
   if( !version || parseInt( version, 10 ) < currentVersion ){
     window.resetEndpoints();


### PR DESCRIPTION
This replaces the Mapzen Search prod_build and dev endpoints with production and dev for [geocode.earth](https://geocode.earth).

A new API key with a small rate limit for geocode.earth has been created specifically for the compare app.

For now, production Mapzen Search remains as the first endpoint, since it is still up. However, it will no doubt soon go away.

Connects https://github.com/pelias/pelias/issues/703