### PR TITLE
Disable X-Requested-With header

### DIFF
--- a/app/controllers/MainController.js
+++ b/app/controllers/MainController.js
@@ -84,7 +84,7 @@ function MainController( $scope, $location, $http, $rootScope ){
           url: target,
           method: 'GET',
           params: params,
-          headers: { 'Accept': 'application/json' }
+          headers: { 'Accept': 'application/json', 'X-Requested-With': '' }
         })
         .success(responseParser)
         .error(responseParser);


### PR DESCRIPTION
This header, while common, is enough to cause the browser to require a CORS preflight request (the `OPTIONS` request) before each call to Pelias.

Disabling it allows the browser to send a single GET request, which shaves a good 30-100ms off the page load time.